### PR TITLE
Fix syntax errors in integration tests

### DIFF
--- a/tests/shnifter_integration_tests/shnifter_test_controllers_base_controller.py
+++ b/tests/shnifter_integration_tests/shnifter_test_controllers_base_controller.py
@@ -1,9 +1,5 @@
 import unittest
-from unittest.mock import Mock, patch
-import pandas as pd
-from datetime import datetime
-
-"""Test the base controller."""
+"""Integration tests for :mod:`shnifter_interface.controllers.base_controller`."""
 
 from unittest.mock import MagicMock, patch
 
@@ -13,7 +9,7 @@ from shnifter_interface.controllers.base_controller import BaseController
 # pylint: disable=unused-argument, unused-variable
 
 
-class TestShnifter\1(BaseController):
+class TestableBaseController(BaseController):
     """Testable Base Controller."""
 
     def __init__(self, queue=None):

--- a/tests/shnifter_integration_tests/shnifter_test_integration_base_controller.py
+++ b/tests/shnifter_integration_tests/shnifter_test_integration_base_controller.py
@@ -1,11 +1,4 @@
-import unittest
-from unittest.mock import Mock, patch
-import pandas as pd
-from datetime import datetime
-
-"""Integration tests for the base_controller module."""
-
-from unittest.mock import Mock, patch
+"""Integration tests for :mod:`shnifter_interface.controllers.base_controller`."""
 
 import pytest
 from shnifter_interface.controllers.base_controller import BaseController
@@ -14,7 +7,7 @@ from shnifter_interface.session import Session
 # pylint: disable=unused-variable, redefined-outer-name
 
 
-class TestShnifter\1(BaseController):
+class TestController(BaseController):
     """Test controller for the BaseController."""
 
     PATH = "/test/"


### PR DESCRIPTION
## Summary
- fix typos in integration test classes

## Testing
- `PYTHONPATH=$PWD pytest tests/test_shnifter_core.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686cc73f3dd08330a7ebdc6332f110af